### PR TITLE
Add options to base command to fix v3 functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,12 @@
 var chokidar = require("chokidar");
+const commandOptions = {
+  function: {
+    usage: "Specify the function you want to develop with serverless-online ",
+    required: true,
+    shortcut: "f",
+    type: "string",
+  },
+};
 
 class ServerlessPlugin {
   constructor(serverless, cliOptions) {
@@ -10,18 +18,11 @@ class ServerlessPlugin {
         commands: {
           start: {
             lifecycleEvents: ["init", "ready", "end"],
-            options: {
-              function: {
-                usage:
-                  "Specify the function you want to develop with serverless-online ",
-                required: true,
-                shortcut: "f",
-                type: "string",
-              },
-            },
+            options: commandOptions,
           },
         },
         lifecycleEvents: ["start"],
+        options: commandOptions,
       },
     };
 


### PR DESCRIPTION
## Purpose

This changeset restores 'sls online' functionality when using serverless v3.

#### Linked Issues to Close

Closes #6 

## Approach

As outlined in #6, serverless' deprecation of free form options caused this bug to surface.  This plugin had been relying on the free form "fucntion" option when calling "sls online --function myfunc --stage mystage" (note the lack of subcommand 'start').  
With the deprecation in v3, the base command began failing.
This changeset makes it so the base command 'sls online' and start subcommand 'sls online start' both define and expect a function parameter.

## Learning

Learning about the deprecation was crucial... https://www.serverless.com/framework/docs/deprecations#handling-of-unrecognized-cli-options
Until I realized that, this was really confusing.

## Assorted Notes/Considerations

N/A

#### Pull Request Creator Checklist

- [x] Any associated issue(s) are linked above.
- [x] This PR and linked issues(s) are a complete description of the changeset.
- [x] Someone has been assigned this PR.
- [ ] Someone has been marked as reviewer on this PR.

#### Pull Request Assignee Checklist

- [x] Any associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for any linked issues.
- [x] This PR and linked issues(s) are a complete description of the changeset.
