### PR TITLE
Set dependabot to update once a week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
## Purpose

This changeset should reduce PR noise generated by Dependabot.  This sets Dependabot to do a proactive (non-security related) upgrade of packages once a week.  Security updates will still be created when vulnerabilities are detected.

#### Linked Issues to Close

N/A

## Approach

Sets update frequency to weekly, per docs.

## Learning

N/A

## Assorted Notes/Considerations

N/A

#### Pull Request Creator Checklist

- [x] Any associated issue(s) are linked above.
- [x] This PR and linked issues(s) are a complete description of the changeset.
- [x] Someone has been assigned this PR.
- [x] Someone has been marked as reviewer on this PR.

#### Pull Request Assignee Checklist

- [ ] Any associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for any linked issues.
- [ ] This PR and linked issues(s) are a complete description of the changeset.
